### PR TITLE
詳細表示機能の実装

### DIFF
--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -1,0 +1,128 @@
+/* コンテナ全体のスタイル */
+.postShow__container {
+  position: fixed;
+  width: 100%;
+  max-width: 800px;
+  top: 10vh;
+  bottom: 10vh;
+  background-color: #f3eae0; /* 背景色 */
+  color: #223148; /* テキストカラー */
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 32px 0;
+}
+
+/* ヘッダー部分のスタイル */
+.postShow__headerText {
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  color: #223148;
+  margin-bottom: 24px;
+  text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* 詳細情報のテーブル */
+.postShow__table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+}
+
+.postShow__table th, 
+.postShow__table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid #d2c7b8;
+}
+
+.postShow__label {
+  font-weight: bold;
+  font-size: 16px;
+  color: #333;
+}
+
+.postShow__value {
+  font-size: 14px;
+  color: #555;
+}
+
+/* 詳細ページのメモ欄 */
+.postShow__value--note {
+  max-height: 200px; /* 最大高さを指定 */
+  overflow-y: auto; /* 縦方向のスクロールを有効に */
+  word-wrap: break-word; /* 単語が長すぎる場合に折り返す */
+  white-space: pre-wrap; /* 改行を保持して表示 */
+  padding: 8px; /* 内容との余白を確保 */
+  border: 1px solid #d2c7b8; /* 境界線を追加して視覚的に区別 */
+  border-radius: 4px; /* 角を少し丸める */
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 軽い影を追加 */
+}
+
+/* アクションボタンのスタイル */
+.postShow__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 24px;
+  padding: 0 32px;
+}
+
+.postShow__editButton,
+.postShow__deleteButton {
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: bold;
+  text-transform: uppercase;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.postShow__editButton {
+  background-color: #5ca5f3;
+  color: white;
+}
+
+.postShow__editButton:hover {
+  background-color: #3a8ed6;
+  transform: scale(1.05);
+}
+
+.postShow__deleteButton {
+  background-color: #f15c5c;
+  color: white;
+}
+
+.postShow__deleteButton:hover {
+  background-color: #d34a4a;
+  transform: scale(1.05);
+}
+
+/* 戻るボタンのスタイル */
+.postShow__backLink {
+  text-align: center;
+  margin-top: 16px;
+}
+
+.postShow__backButton {
+  display: inline-block;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: bold;
+  color: white;
+  background-color: #2f486d;
+  text-decoration: none;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.postShow__backButton:hover {
+  background-color: #223148;
+  transform: scale(1.05);
+}

--- a/app/assets/stylesheets/shared/header.css
+++ b/app/assets/stylesheets/shared/header.css
@@ -21,17 +21,40 @@
   transform: translateX(-50%);
 }
 
+.user-info {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+}
+
 .user-icon {
   width: 40px;
   height: 40px;
   border-radius: 50%;
   overflow: hidden;
   border: 2px solid #223148;
-  margin-left: 16px;
+  margin-right: 8px;
 }
 
 .user-profile-icon {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.user-name {
+  font-size: 1em;
+  color: #333;
+  margin-right: 16px;
+}
+
+.logout {
+  font-size: 1em;
+  text-decoration: none;
+  color: #223148;
+  font-weight: bold;
+}
+
+.logout:hover {
+  text-decoration: underline;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,6 +23,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,56 @@
+<%= render "shared/header" %>
+
+<div class="postShow__container">
+  <div class="postShow__headerText">
+    <%= @post.title %>
+  </div>
+
+  <div class="postShow__details">
+    <table class="postShow__table">
+      <tbody>
+        <tr>
+          <th class="postShow__label">タイトル</th>
+          <td class="postShow__value"><%= @post.title %></td>
+        </tr>
+        <tr>
+          <th class="postShow__label">予定日</th>
+          <td class="postShow__value"><%= @post.scheduled_date.strftime('%Y年%m月%d日') %></td>
+        </tr>
+        <tr>
+          <th class="postShow__label">バイクジャンル</th>
+          <td class="postShow__value"><%= @post.bike_genre.name %></td>
+        </tr>
+        <tr>
+          <th class="postShow__label">排気量</th>
+          <td class="postShow__value"><%= @post.engine_capacity.name %></td>
+        </tr>
+        <tr>
+          <th class="postShow__label">都道府県</th>
+          <td class="postShow__value"><%= @post.prefecture.name %></td>
+        </tr>
+        <tr>
+        <th class="postShow__label">メモ</th>
+          <td class="postShow__value postShow__value--note">
+          <%= @post.note.presence || 'メモはありません' %>
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+  </div>
+
+  <% if user_signed_in? %>
+    <% if current_user == @post.user %>
+      <div class="postShow__actions">
+        <%= link_to "編集する", edit_post_path(@post), class: "postShow__editButton" %>
+        <%= link_to "削除する", post_path(@post), method: :delete, class: "postShow__deleteButton", data: { confirm: "本当に削除しますか？" } %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="postShow__backLink">
+    <%= link_to "投稿一覧に戻る", posts_path, class: "postShow__backButton" %>
+  </div>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,10 @@
 <header class="header">
-    <h1 class="app-title">TourLink</h1>
+  <h1 class="app-title">TourLink</h1>
+  <div class="user-info">
     <div class="user-icon">
       <%= image_tag(current_user.profile_image, alt: "User Icon", class: "user-profile-icon") %>
     </div>
+    <span class="user-name"><%= current_user.nickname %></span>
+  </div>
+  <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "logout" %>
 </header>

--- a/app/views/top_screen/index.html.erb
+++ b/app/views/top_screen/index.html.erb
@@ -4,7 +4,6 @@
     <title>TourLink</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "top_screen", media: "all" %>
   </head>
 
   <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   root to: 'posts#index'
+
   resources :top_screen, only: [:index]
   resources :posts
+  
   devise_for :users, controllers: {
-  registrations: 'users/registrations'
-}
-
- 
+    registrations: 'users/registrations'
+  }
 end


### PR DESCRIPTION
# What
- 投稿の詳細表示機能を実装しました。
- 投稿一覧画面から特定の投稿をクリックすることで、詳細ページに遷移し、投稿内容を確認できるようにしました。
- 詳細表示画面では以下の情報を表示します：
  - 投稿タイトル
  - 投稿内容
  - 投稿者のニックネーム
  - 投稿日時
  - 投稿に紐づくバイク情報（ジャンルや排気量など）

# Why
- 投稿の詳細を確認できる機能は、アプリの基本的な操作性を向上させるために必要です。
- ユーザーが他者の投稿内容を詳細に理解し、それを基にコミュニケーションを取ったり、ツーリングの参考にしたりすることを想定しています。
- 特に、バイク情報や投稿の背景に関する詳細が分かることで、ツーリング仲間の募集や交流がより円滑になります。
- 今後、コメント機能やグループチャット機能と連携するための基盤となります。