### PR TITLE
投稿削除機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -40,6 +40,15 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = Post.find(params[:id])
+    if @post.destroy
+      redirect_to root_path, notice: "投稿を削除しました。"
+    else
+      redirect_to post_path(@post), alert: "投稿の削除に失敗しました。"
+    end
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,7 @@
 class PostsController < ApplicationController
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_user!, only: [:edit, :update, :destroy]
+
   def index
     if user_signed_in?
       @posts = Post.all.order(created_at: :desc)
@@ -23,16 +26,11 @@ class PostsController < ApplicationController
     end
   end
 
-  def show
-    @post = Post.find(params[:id])
-  end
+  def show; end
 
-  def edit
-    @post = Post.find(params[:id])
-  end
+  def edit; end
 
   def update
-     @post = Post.find(params[:id])
     if @post.update(post_params)
       redirect_to root_path
     else
@@ -41,7 +39,6 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post = Post.find(params[:id])
     if @post.destroy
       redirect_to root_path, notice: "投稿を削除しました。"
     else
@@ -50,6 +47,16 @@ class PostsController < ApplicationController
   end
 
   private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def authorize_user!
+    unless @post.user == current_user
+      redirect_to root_path
+    end
+  end
 
   def post_params
     params.require(:post).permit(:title, :bike_genre_id, :engine_capacity_id, :prefecture_id, :note, :scheduled_date)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -43,7 +43,7 @@
     <% if current_user == @post.user %>
       <div class="postShow__actions">
         <%= link_to "編集する", edit_post_path(@post), class: "postShow__editButton", data: { turbo: false } %>
-        <%= link_to "削除する", post_path(@post), method: :delete, class: "postShow__deleteButton", data: { confirm: "本当に削除しますか？" } %>
+        <%= link_to "削除する", post_path(@post), data: { turbo_method: :delete }, class: "postShow__deleteButton" %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
# What
**投稿削除機能の実装**  
   - 削除後はトップページにリダイレクトされるようにしました。  
   - 他のユーザーがURLを直接指定しても投稿を削除できないよう、投稿の所有者のみが削除できる制御を追加しました。


# Why
**投稿削除機能の改善**  
   - 削除後に投稿詳細ページが残るとエラーが発生するため、削除後はトップページにリダイレクトするように変更。  
   - セキュリティ向上のため、他のユーザーによる不正な削除操作を防ぐ必要があるため、投稿の所有者をチェックする処理を追加。

**アプリ全体へのアクセス制限**  
   - アプリが提供するサービスを保護し、意図しない利用を防ぐため、ログイン済みユーザーのみが利用できるように設定。  
   - 認証されていないユーザーがアプリにアクセスしようとした場合、ログインページにリダイレクトされることで、適切な利用を促進。  
