### PR TITLE
Basic認証の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   
@@ -6,5 +7,11 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :profile_image, :gender_id, :age_group_id])
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
   end
 end


### PR DESCRIPTION
# What
- Basic認証を導入し、アプリケーションのセキュリティを向上させるために環境変数を使用して認証情報を管理しました。

#Why
- アプリケーションの未認証アクセスを防ぐため。
- 認証情報をコード内に直接記載せず、環境変数を使用することでセキュリティリスクを軽減するため。