### PR TITLE
投稿削除時に関連コメントも自動削除されるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,6 +35,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    @post.comments.destroy_all
     if @post.destroy
       redirect_to root_path
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,7 +5,7 @@ class Post < ApplicationRecord
   belongs_to_active_hash :prefecture
 
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
 
   validates :title, presence: true
   validates :scheduled_date, presence: true


### PR DESCRIPTION
## What
投稿を削除する際に、関連するコメントも自動的に削除されるように修正しました。  

## Why
投稿に紐づくコメントが存在する場合、外部キー制約により投稿の削除ができずエラーが発生していました。この問題を解決するために、関連コメントも同時に削除されるように設定し、エラーを回避できるようにしました。  
