### PR TITLE
投稿削除時に関連データも削除されるよう修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,6 +36,8 @@ class PostsController < ApplicationController
 
   def destroy
     @post.comments.destroy_all
+    @post.requests.destroy_all
+    @post.notifications.destroy_all
     if @post.destroy
       redirect_to root_path
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,8 +6,8 @@ class Post < ApplicationRecord
 
   belongs_to :user
   has_many :comments, dependent: :destroy
-  has_many :requests
-  has_many :notifications
+  has_many :requests, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   validates :title, presence: true
   validates :scheduled_date, presence: true


### PR DESCRIPTION
### What

- Post削除時に、関連付けられたコメントやリクエストが削除されず、外部キー制約エラーが発生する問題を修正しました。
- 以下の変更を実施しました：
  - Postモデルに dependent: :destroyを設定し、関連付けられたデータ（comments と requests）が投稿削除時に自動で削除されるようにしました。

---

### Why

- 投稿を削除する際に、関連するデータ（コメントやリクエスト）が存在するため、外部キー制約によってエラーが発生していました。
- ユーザーが投稿を正常に削除できるようにするため、関連データも適切に削除されるよう修正しました。これにより、操作性とデータ整合性が向上します。